### PR TITLE
Flujo RegistroAsesor Terminado

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="previ">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/app/src/main/java/com/andres_lasso/previmed/controller/asesor/AsociarBeneficiario.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/controller/asesor/AsociarBeneficiario.kt
@@ -4,6 +4,7 @@ import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
+import com.andres_lasso.previmed.utils.GlobalData
 import android.os.Looper
 import android.view.View
 import android.widget.*
@@ -197,12 +198,24 @@ class AsociarBeneficiario : AppCompatActivity() {
 
     /** 🔹 Navegar a la pantalla de Registrar Pago */
     private fun irARegistrarPago() {
+        val membresiaId = GlobalData.ultimaMembresiaId ?: -1
+        val formaPagoId = intent.getIntExtra("FORMA_PAGO_ID", -1)
+        val formaPago = intent.getStringExtra("FORMA_PAGO") ?: "Desconocido"
+
+        android.util.Log.d("AsociarBeneficiario", "➡️ Ir a registrar pago con MEMBRESIA_ID=$membresiaId")
+
+        if (membresiaId == -1) {
+            Toast.makeText(this, "⚠️ No se encontró una membresía válida", Toast.LENGTH_SHORT).show()
+            return
+        }
+
         val intent = Intent(this, RegistrarPagoActivity::class.java)
-        intent.putExtra("MEMBRESIA_ID", 1)
-        intent.putExtra("FORMA_PAGO_ID", 1)
-        intent.putExtra("FORMA_PAGO", "Efectivo")
+        intent.putExtra("MEMBRESIA_ID", membresiaId)
+        intent.putExtra("FORMA_PAGO_ID", formaPagoId)
+        intent.putExtra("FORMA_PAGO", formaPago)
         startActivity(intent)
     }
+
 
     /** 🔹 Mostrar diálogo con autocierre */
     private fun mostrarDialogo(titulo: String, mensaje: String) {

--- a/app/src/main/java/com/andres_lasso/previmed/controller/asesor/ContratoActivity.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/controller/asesor/ContratoActivity.kt
@@ -2,6 +2,7 @@ package com.andres_lasso.previmed.controller.asesor
 
 import android.app.DatePickerDialog
 import android.content.Intent
+import com.andres_lasso.previmed.utils.GlobalData
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -138,7 +139,7 @@ class ContratoActivity : AppCompatActivity() {
                         val idMembresia = membresiaCreada.idMembresia ?: 0
 
                         Log.d("ContratoActivity", "✅ ID obtenido directamente: $idMembresia")
-                        Log.d("ContratoActivity", "🧩 Detalle completo: $membresiaCreada")
+                        GlobalData.ultimaMembresiaId = idMembresia // ✅ Guardamos globalmente
 
                         tvIdMembresia.text = "Contrato creado con ID: $idMembresia"
                         tvIdMembresia.visibility = View.VISIBLE
@@ -151,14 +152,14 @@ class ContratoActivity : AppCompatActivity() {
 
                         // Ir a la pantalla siguiente
                         val intent = Intent(this@ContratoActivity, AsociarBeneficiario::class.java)
-                        intent.putExtra("MEMBRESIA_ID", idMembresia)
                         intent.putExtra("FORMA_PAGO", formaPago)
                         intent.putExtra("FORMA_PAGO_ID", formaPagoId)
                         intent.putExtra("PLAN_ID", planId ?: -1)
                         intent.putExtra("PACIENTE_ID_TITULAR", pacienteId ?: -1)
                         startActivity(intent)
                         finish()
-                    } else {
+                    }
+                    else {
                         Toast.makeText(
                             this@ContratoActivity,
                             "Error al registrar contrato: ${response.message()}",

--- a/app/src/main/java/com/andres_lasso/previmed/controller/asesor/RegistrarPagoActivity.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/controller/asesor/RegistrarPagoActivity.kt
@@ -19,27 +19,26 @@ import java.util.*
 class RegistrarPagoActivity : AppCompatActivity() {
 
     private lateinit var etMonto: EditText
+    private lateinit var etFechaInicio: EditText
+    private lateinit var etFechaFin: EditText
     private lateinit var etFechaPago: EditText
     private lateinit var btnRegistrarPago: Button
     private lateinit var btnNuevoPago: Button
     private lateinit var tvMembresia: TextView
     private lateinit var tvFormaPago: TextView
-    private lateinit var tvFechasContrato: TextView
-    private lateinit var btnSubirFoto: Button
-    private lateinit var imgPreview: ImageView
     private lateinit var progressBar: ProgressBar
 
     private var membresiaId: Int = -1
     private var formaPagoId: Int = 0
-    private var fechaInicio: String = ""
-    private var fechaFin: String = ""
+
+    private val TAG = "RegistrarPago"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_registro_pago)
 
         initViews()
-        setupDatePicker()
+        setupDatePickers()
         recibirDatosIntent()
 
         btnRegistrarPago.setOnClickListener {
@@ -49,59 +48,58 @@ class RegistrarPagoActivity : AppCompatActivity() {
         btnNuevoPago.setOnClickListener { limpiarCampos() }
     }
 
-    /** Inicializa vistas */
     private fun initViews() {
         etMonto = findViewById(R.id.etMonto)
+        etFechaInicio = findViewById(R.id.etFechaInicio)
+        etFechaFin = findViewById(R.id.etFechaFin)
         etFechaPago = findViewById(R.id.etFechaPago)
         btnRegistrarPago = findViewById(R.id.btnRegistrarPago)
         btnNuevoPago = findViewById(R.id.btnNuevoPago)
         tvMembresia = findViewById(R.id.tvMembresia)
         tvFormaPago = findViewById(R.id.tvFormaPago)
-        tvFechasContrato = findViewById(R.id.tvFechasContrato)
-        btnSubirFoto = findViewById(R.id.btnSubirFoto)
-        imgPreview = findViewById(R.id.imgPreview)
-        progressBar = findViewById(R.id.pbCargandoPago)
-
-        // Ocultar botones e imagen hasta implementar subida
-        btnSubirFoto.visibility = View.GONE
-        imgPreview.visibility = View.GONE
+        progressBar = findViewById(R.id.pbCargargandu)
     }
 
-    /** Recibe los datos de la membresía y forma de pago */
     private fun recibirDatosIntent() {
         membresiaId = intent.getIntExtra("MEMBRESIA_ID", -1)
         formaPagoId = intent.getIntExtra("FORMA_PAGO_ID", 0)
-        fechaInicio = intent.getStringExtra("FECHA_INICIO") ?: ""
-        fechaFin = intent.getStringExtra("FECHA_FIN") ?: ""
-        val numeroContrato = intent.getStringExtra("NUMERO_CONTRATO") ?: "Sin contrato"
         val formaPagoTexto = intent.getStringExtra("FORMA_PAGO") ?: "Desconocido"
 
-        tvMembresia.text = "Membresía ID: $membresiaId"
-        tvFormaPago.text = "Forma de pago: $formaPagoTexto"
-        tvFechasContrato.text = "Contrato: $numeroContrato\n($fechaInicio → $fechaFin)"
+        tvMembresia.text = "🪪 Membresía N° $membresiaId"
+        tvFormaPago.text = "💳 Forma de pago: $formaPagoTexto"
+
+        Log.d(TAG, "📥 Datos recibidos -> MEMBRESIA_ID=$membresiaId, FORMA_PAGO_ID=$formaPagoId, FORMA_PAGO=$formaPagoTexto")
     }
 
-    /** Selector de fecha */
-    private fun setupDatePicker() {
-        etFechaPago.setOnClickListener {
+    private fun setupDatePickers() {
+        val listener = { et: EditText ->
             val c = Calendar.getInstance()
             DatePickerDialog(
                 this,
                 { _, year, month, day ->
-                    etFechaPago.setText(String.format("%04d-%02d-%02d", year, month + 1, day))
+                    et.setText(String.format("%04d-%02d-%02d", year, month + 1, day))
                 },
                 c.get(Calendar.YEAR),
                 c.get(Calendar.MONTH),
                 c.get(Calendar.DAY_OF_MONTH)
             ).show()
         }
+
+        etFechaInicio.setOnClickListener { listener(etFechaInicio) }
+        etFechaFin.setOnClickListener { listener(etFechaFin) }
+        etFechaPago.setOnClickListener { listener(etFechaPago) }
     }
 
-    /** Validar campos */
     private fun validarCampos(): Boolean {
         return when {
             etMonto.text.isNullOrBlank() -> {
                 Toast.makeText(this, "💰 El monto es obligatorio", Toast.LENGTH_SHORT).show(); false
+            }
+            etFechaInicio.text.isNullOrBlank() -> {
+                Toast.makeText(this, "📅 Selecciona la fecha de inicio", Toast.LENGTH_SHORT).show(); false
+            }
+            etFechaFin.text.isNullOrBlank() -> {
+                Toast.makeText(this, "📅 Selecciona la fecha de fin", Toast.LENGTH_SHORT).show(); false
             }
             etFechaPago.text.isNullOrBlank() -> {
                 Toast.makeText(this, "📅 Selecciona la fecha de pago", Toast.LENGTH_SHORT).show(); false
@@ -109,39 +107,47 @@ class RegistrarPagoActivity : AppCompatActivity() {
             membresiaId == -1 -> {
                 Toast.makeText(this, "❗ Falta el ID de membresía", Toast.LENGTH_SHORT).show(); false
             }
-            fechaInicio.isBlank() || fechaFin.isBlank() -> {
-                Toast.makeText(this, "⚠️ Faltan fechas del contrato", Toast.LENGTH_SHORT).show(); false
-            }
             else -> true
         }
     }
 
-    /** Limpia campos */
     private fun limpiarCampos() {
         etMonto.text.clear()
+        etFechaInicio.text.clear()
+        etFechaFin.text.clear()
         etFechaPago.text.clear()
+        Log.d(TAG, "🧹 Campos limpiados")
     }
 
-    /** Registrar pago en el backend */
     private fun registrarPago() {
         val monto = etMonto.text.toString().toDouble()
+        val fechaInicio = etFechaInicio.text.toString()
+        val fechaFin = etFechaFin.text.toString()
         val fechaPago = etFechaPago.text.toString()
 
-        val pago = PagoRequest(
-            monto = monto,
-            fecha_inicio = fechaInicio,
-            fecha_fin = fechaFin,
-            fecha_pago = fechaPago,
-            membresia_id = membresiaId,
-            forma_pago_id = formaPagoId,
-            foto = null
-        )
+        Log.d(TAG, "🚀 Enviando pago sin foto:")
+        Log.d(TAG, "   monto=$monto")
+        Log.d(TAG, "   fecha_inicio=$fechaInicio")
+        Log.d(TAG, "   fecha_fin=$fechaFin")
+        Log.d(TAG, "   fecha_pago=$fechaPago")
+        Log.d(TAG, "   membresia_id=$membresiaId")
+        Log.d(TAG, "   forma_pago_id=$formaPagoId")
 
         progressBar.visibility = View.VISIBLE
         btnRegistrarPago.isEnabled = false
 
         CoroutineScope(Dispatchers.IO).launch {
             try {
+                val pago = PagoRequest(
+                    monto = monto,
+                    fecha_inicio = fechaInicio,
+                    fecha_fin = fechaFin,
+                    fecha_pago = fechaPago,
+                    membresia_id = membresiaId,
+                    forma_pago_id = formaPagoId,
+                    foto = null
+                )
+
                 val response = RetrofitClient.pagoApi.createPago(pago)
 
                 runOnUiThread {
@@ -149,19 +155,13 @@ class RegistrarPagoActivity : AppCompatActivity() {
                     btnRegistrarPago.isEnabled = true
 
                     if (response.isSuccessful) {
-                        Toast.makeText(
-                            this@RegistrarPagoActivity,
-                            "✅ Pago registrado correctamente",
-                            Toast.LENGTH_LONG
-                        ).show()
+                        Log.i(TAG, "✅ Pago registrado correctamente: ${response.body()}")
+                        Toast.makeText(this@RegistrarPagoActivity, "✅ Pago registrado correctamente", Toast.LENGTH_LONG).show()
                         limpiarCampos()
                     } else {
-                        Toast.makeText(
-                            this@RegistrarPagoActivity,
-                            "❌ Error al registrar pago (${response.code()})",
-                            Toast.LENGTH_LONG
-                        ).show()
-                        Log.e("RegistrarPago", "Error body: ${response.errorBody()?.string()}")
+                        val errorBody = response.errorBody()?.string()
+                        Log.e(TAG, "❌ Error al registrar pago (${response.code()}): $errorBody")
+                        Toast.makeText(this@RegistrarPagoActivity, "❌ Error al registrar pago (${response.code()})", Toast.LENGTH_LONG).show()
                     }
                 }
 
@@ -169,12 +169,8 @@ class RegistrarPagoActivity : AppCompatActivity() {
                 runOnUiThread {
                     progressBar.visibility = View.GONE
                     btnRegistrarPago.isEnabled = true
-                    Toast.makeText(
-                        this@RegistrarPagoActivity,
-                        "⚠️ Falló la conexión o hubo un error inesperado",
-                        Toast.LENGTH_LONG
-                    ).show()
-                    Log.e("RegistrarPago", "Error: ${e.message}", e)
+                    Log.e(TAG, "⚠️ Excepción: ${e.message}", e)
+                    Toast.makeText(this@RegistrarPagoActivity, "⚠️ Error de conexión o excepción inesperada", Toast.LENGTH_LONG).show()
                 }
             }
         }
@@ -185,17 +181,11 @@ class RegistrarPagoActivity : AppCompatActivity() {
             context: Context,
             membresiaId: Int,
             formaPagoId: Int,
-            fechaInicioStr: String,
-            fechaFinStr: String,
-            numeroContrato: String,
             formaPago: String? = null
         ) {
             val intent = Intent(context, RegistrarPagoActivity::class.java).apply {
                 putExtra("MEMBRESIA_ID", membresiaId)
                 putExtra("FORMA_PAGO_ID", formaPagoId)
-                putExtra("FECHA_INICIO", fechaInicioStr)
-                putExtra("FECHA_FIN", fechaFinStr)
-                putExtra("NUMERO_CONTRATO", numeroContrato)
                 putExtra("FORMA_PAGO", formaPago)
             }
             context.startActivity(intent)

--- a/app/src/main/java/com/andres_lasso/previmed/interfaces/PagoApi.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/interfaces/PagoApi.kt
@@ -2,10 +2,14 @@ package com.andres_lasso.previmed.interfaces
 
 import com.andres_lasso.previmed.model.PagoModel
 import com.andres_lasso.previmed.model.PagoRequest
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 
 interface PagoApi {
     @GET("registros-pago")
@@ -13,4 +17,17 @@ interface PagoApi {
 
     @POST("registro-pago")
     suspend fun createPago(@Body pago: PagoRequest): Response<PagoModel>
+
+    @Multipart
+    @POST("registro-pago")
+    suspend fun createPagoConFoto(
+        @Part("monto") monto: RequestBody,
+        @Part("fecha_inicio") fechaInicio: RequestBody,
+        @Part("fecha_fin") fechaFin: RequestBody,
+        @Part("fecha_pago") fechaPago: RequestBody,
+        @Part("membresia_id") membresiaId: RequestBody,
+        @Part("forma_pago_id") formaPagoId: RequestBody,
+        @Part foto: MultipartBody.Part?
+    ): Response<PagoModel>
+
 }

--- a/app/src/main/java/com/andres_lasso/previmed/utils/GlobalData.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/utils/GlobalData.kt
@@ -1,0 +1,5 @@
+package com.andres_lasso.previmed.utils
+
+object GlobalData {
+    var ultimaMembresiaId: Int? = null
+}

--- a/app/src/main/java/com/andres_lasso/previmed/utils/RequestBodyUtils.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/utils/RequestBodyUtils.kt
@@ -1,0 +1,8 @@
+package com.andres_lasso.previmed.utils
+
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+fun String.toPlainRequestBody(): RequestBody =
+    this.toRequestBody("text/plain".toMediaTypeOrNull())

--- a/app/src/main/res/layout/activity_registro_pago.xml
+++ b/app/src/main/res/layout/activity_registro_pago.xml
@@ -58,6 +58,46 @@
                 android:padding="10dp"
                 android:layout_marginTop="8dp" />
 
+            <!-- 📅 Fecha de inicio -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Fecha de Inicio"
+                android:textColor="#2196F3"
+                android:textStyle="bold"
+                android:layout_marginTop="16dp" />
+
+            <EditText
+                android:id="@+id/etFechaInicio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Selecciona fecha de inicio"
+                android:focusable="false"
+                android:clickable="true"
+                android:background="@android:color/white"
+                android:padding="10dp"
+                android:layout_marginTop="8dp" />
+
+            <!-- 📅 Fecha de fin -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Fecha de Fin"
+                android:textColor="#2196F3"
+                android:textStyle="bold"
+                android:layout_marginTop="16dp" />
+
+            <EditText
+                android:id="@+id/etFechaFin"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Selecciona fecha de fin"
+                android:focusable="false"
+                android:clickable="true"
+                android:background="@android:color/white"
+                android:padding="10dp"
+                android:layout_marginTop="8dp" />
+
             <!-- 📅 Fecha de pago -->
             <TextView
                 android:layout_width="match_parent"
@@ -94,48 +134,39 @@
                 android:layout_height="wrap_content"
                 android:background="@android:color/white"
                 android:padding="10dp"
-                android:text="Forma de pago ID: -"
+                android:text="Forma de pago: -"
                 android:layout_marginTop="8dp" />
 
-            <TextView
-                android:id="@+id/tvFechasContrato"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@android:color/white"
-                android:padding="10dp"
-                android:text="Contrato: "
-                android:layout_marginTop="8dp" />
 
-            <!-- 📸 Subir foto -->
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Comprobante (Foto)"
-                android:textColor="#2196F3"
-                android:textStyle="bold"
-                android:layout_marginTop="16dp" />
+            <!--  <TextView
+                 android:layout_width="match_parent"
+                 android:layout_height="wrap_content"
+                 android:text="Comprobante (Foto)"
+                 android:textColor="#2196F3"
+                 android:textStyle="bold"
+                 android:layout_marginTop="16dp" />
 
-            <Button
-                android:id="@+id/btnSubirFoto"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Seleccionar Imagen"
-                android:backgroundTint="#03A9F4"
-                android:textColor="@android:color/white"
-                android:layout_marginTop="8dp" />
+             <Button
+                 android:id="@+id/btnSubirFoto"
+                 android:layout_width="match_parent"
+                 android:layout_height="wrap_content"
+                 android:text="Seleccionar Imagen"
+                 android:backgroundTint="#03A9F4"
+                 android:textColor="@android:color/white"
+                 android:layout_marginTop="8dp" />
 
-            <ImageView
-                android:id="@+id/imgPreview"
-                android:layout_width="220dp"
-                android:layout_height="220dp"
-                android:layout_gravity="center"
-                android:layout_marginTop="10dp"
-                android:scaleType="centerCrop"
-                android:background="#E0E0E0"
-                android:visibility="gone" />
+             <ImageView
+                 android:id="@+id/imgPreview"
+                 android:layout_width="220dp"
+                 android:layout_height="220dp"
+                 android:layout_gravity="center"
+                 android:layout_marginTop="10dp"
+                 android:scaleType="centerCrop"
+                 android:background="#E0E0E0"
+                 android:visibility="gone" />-->
 
             <ProgressBar
-                android:id="@+id/pbCargandoPago"
+                android:id="@+id/pbCargargandu"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"


### PR DESCRIPTION
Funciona RegistroPago y se desabilito la foto.
Detalles:
Se eliminaron referencias a btnSubirFoto, imgPreview y selectedImageUri.
Se removió el uso de ActivityResultContracts.GetContent() y el método uriToFile().
Ahora todos los registros de pago se envían mediante el endpoint estándar createPago() sin imagen.
Se mantuvo intacta la lógica de validaciones, fechas y limpieza de campos.
No se realizaron cambios en el XML, ya que las vistas de imagen estaban comentadas.
