### PR TITLE
Home asesor pagos / flujo registro usuario pagos ready!

### DIFF
--- a/app/src/main/java/com/andres_lasso/previmed/controller/Login.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/controller/Login.kt
@@ -35,14 +35,12 @@ class Login : AppCompatActivity() {
 
     private var isLoggingIn = false
 
-    // 🔤 Normaliza el rol eliminando tildes y convirtiendo a minúsculas
     private fun normalizeRole(raw: String?): String {
         if (raw.isNullOrBlank()) return ""
         val normalized = Normalizer.normalize(raw, Normalizer.Form.NFD)
         return normalized.replace("\\p{Mn}+".toRegex(), "").lowercase()
     }
 
-    // 🚀 Redirige según el rol del usuario
     private fun goToRoleActivity(role: String) {
         val destination = when (role) {
             "beneficiario", "paciente" -> ViewBeneficiario::class.java
@@ -79,7 +77,6 @@ class Login : AppCompatActivity() {
 
         Log.d("LOGIN", "🚀 LoginActivity creado")
 
-        // 🔐 Si ya hay token, entrar directo
         if (PreferenceHelper.hasToken(this)) {
             val savedRole = PreferenceHelper.getRole(this)
             Log.d("LOGIN", "Token existente, rol: $savedRole")
@@ -92,9 +89,8 @@ class Login : AppCompatActivity() {
             }
         }
 
-        // 🟢 Acción del botón de login
         btnLogin.setOnClickListener {
-            if (isLoggingIn) return@setOnClickListener  // ⛔ Evita clics múltiples
+            if (isLoggingIn) return@setOnClickListener
 
             val documento = ctdocumento.text.toString().trim()
             val password = ctpassword.text.toString().trim()
@@ -129,49 +125,29 @@ class Login : AppCompatActivity() {
 
                     try {
                         if (response.isSuccessful) {
-                            val body = response.body()
 
+                            val body = response.body()
                             if (body == null) {
-                                Toast.makeText(
-                                    this@Login,
-                                    "Error al procesar la respuesta del servidor.",
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                                Log.e("LOGIN", "❌ Respuesta nula del servidor")
+                                Toast.makeText(this@Login, "Error al procesar respuesta.", Toast.LENGTH_SHORT).show()
                                 return
                             }
 
-                            // ✅ Caso: servidor responde 200 sin token ni data (por ejemplo: "Usuario no encontrado")
                             if (body.jwt.isNullOrEmpty() || body.data == null) {
-                                val mensajeServidor = body.msg ?: body.message ?: ""
-
-                                if (mensajeServidor.contains("no encontrado", ignoreCase = true) ||
-                                    mensajeServidor.contains("credenciales", ignoreCase = true) ||
-                                    mensajeServidor.contains("incorrect", ignoreCase = true)
-                                ) {
-                                    Toast.makeText(
-                                        this@Login,
-                                        "Credenciales incorrectas. Verifique su documento o contraseña.",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
-                                    Log.w("LOGIN", "⚠️ Credenciales incorrectas detectadas: $mensajeServidor")
-                                    return
-                                } else {
-                                    Toast.makeText(
-                                        this@Login,
-                                        "Error al procesar la respuesta del servidor.",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
-                                    Log.e("LOGIN", "❌ Respuesta incompleta del servidor: $mensajeServidor")
-                                    return
-                                }
+                                Toast.makeText(this@Login, body.msg ?: "Credenciales incorrectas", Toast.LENGTH_SHORT).show()
+                                return
                             }
 
                             val roleNormalized = normalizeRole(body.data.rol?.nombreRol)
-                            val usuarioId = body.data.id
+                            val usuarioId = body.data.id   // UUID del asesor/paciente/médico
 
+                            // ✔ Guardamos token y rol
                             PreferenceHelper.saveToken(this@Login, body.jwt)
                             PreferenceHelper.saveRole(this@Login, roleNormalized)
+                            PreferenceHelper.saveIdAsesor(this@Login, usuarioId)
+
+
+                            // ⭐ ***AQUÍ ESTÁ EL CAMBIO IMPORTANTE***
+                            PreferenceHelper.saveUsuarioId(this@Login, usuarioId)
 
                             Log.d("LOGIN", "✅ Login exitoso - UUID: $usuarioId - Rol: $roleNormalized")
 
@@ -179,30 +155,17 @@ class Login : AppCompatActivity() {
                                 "paciente" -> obtenerIdPaciente(usuarioId, roleNormalized)
                                 "medico" -> obtenerIdMedico(usuarioId, roleNormalized)
                                 else -> {
-                                    Toast.makeText(
-                                        this@Login,
-                                        body.message ?: "Inicio de sesión correcto",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
+                                    Toast.makeText(this@Login, "Inicio de sesión correcto", Toast.LENGTH_SHORT).show()
                                     goToRoleActivity(roleNormalized)
                                 }
                             }
-                        } else {
-                            // 💬 Mensajes personalizados según el código HTTP
-                            val errorMessage = when (response.code()) {
-                                400, 401 -> "Credenciales incorrectas. Verifique su documento o contraseña."
-                                403 -> "No tiene permisos para acceder."
-                                404 -> "Usuario no encontrado."
-                                500 -> "Credenciales incorrectas. Verifique su documento o contraseña."
-                                else -> "Error desconocido (${response.code()})."
-                            }
 
-                            Toast.makeText(this@Login, errorMessage, Toast.LENGTH_SHORT).show()
-                            Log.e("LOGIN", "⚠️ Error de respuesta: ${response.code()} - ${response.errorBody()?.string()}")
+                        } else {
+                            Toast.makeText(this@Login, "Credenciales incorrectas", Toast.LENGTH_SHORT).show()
                         }
+
                     } catch (e: Exception) {
                         Toast.makeText(this@Login, "Error inesperado: ${e.localizedMessage}", Toast.LENGTH_SHORT).show()
-                        Log.e("LOGIN", "💥 Excepción inesperada al procesar login: ${e.message}", e)
                     }
                 }
 
@@ -212,78 +175,45 @@ class Login : AppCompatActivity() {
                     progressBar.visibility = View.GONE
                     btnLogin.text = "Ingresar"
 
-                    val msg = t.message ?: "No se pudo conectar con el servidor"
-                    Toast.makeText(this@Login, "Error de conexión: $msg", Toast.LENGTH_SHORT).show()
-                    Log.e("LOGIN", "Fallo conexión: $msg", t)
+                    Toast.makeText(this@Login, "Error de conexión: ${t.message}", Toast.LENGTH_SHORT).show()
                 }
             })
     }
 
-    // 🟢 MÉDICO → obtener id_medico con el usuario_id
     private fun obtenerIdMedico(usuarioId: String, role: String) {
         lifecycleScope.launch {
             try {
-                Log.d("LOGIN", "🔍 Buscando médico con usuario_id: $usuarioId")
-
                 val response = RetrofitClient.medicoApi.obtenerMedicoPorUsuario(usuarioId)
-
-                if (response.isSuccessful && response.body() != null) {
-                    val medicoResponse = response.body()
-                    val medico = medicoResponse?.msj
-
-                    if (medico != null) {
-                        PreferenceHelper.saveIdMedico(this@Login, medico.id_medico)
-                        Log.d("LOGIN", "✅ Médico encontrado: ${medico.id_medico}")
-                        goToRoleActivity(role)
-                    } else {
-                        Toast.makeText(
-                            this@Login,
-                            "No se encontró médico",
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
+                if (response.isSuccessful && response.body()?.msj != null) {
+                    val medico = response.body()!!.msj
+                    PreferenceHelper.saveIdMedico(this@Login, medico.id_medico)
+                    goToRoleActivity(role)
                 } else {
-                    Toast.makeText(
-                        this@Login,
-                        "Error al obtener médico",
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    Toast.makeText(this@Login, "No se encontró médico", Toast.LENGTH_SHORT).show()
                 }
-
             } catch (e: Exception) {
-                Log.e("LOGIN", "❌ Error: ${e.message}")
+                Log.e("LOGIN", "Error: ${e.message}")
             }
         }
     }
 
-    // 🧍 PACIENTE → obtener id_paciente con el usuario_id
     private fun obtenerIdPaciente(usuarioId: String, role: String) {
         lifecycleScope.launch {
             try {
-                Log.d("LOGIN", "🔍 Obteniendo perfil para UUID: $usuarioId")
-
                 val response = withContext(Dispatchers.IO) {
                     RetrofitClient.pacienteApi.getPacienteByUsuarioId(usuarioId).execute()
                 }
 
-                if (response.isSuccessful && response.body() != null) {
-                    val idPaciente = response.body()!!.data?.idPaciente
+                if (response.isSuccessful && response.body()?.data != null) {
+                    val idPaciente = response.body()!!.data!!.idPaciente
                     PreferenceHelper.saveIdPaciente(this@Login, idPaciente.toString())
                     PreferenceHelper.saveUsuarioId(this@Login, usuarioId)
-
-                    Log.d("LOGIN", "✅ ID paciente: $idPaciente | UUID guardado: $usuarioId")
                     goToRoleActivity(role)
                 } else {
-                    Log.e("LOGIN", "Error ${response.code()} - ${response.errorBody()?.string()}")
-                    Toast.makeText(
-                        this@Login,
-                        "Error obteniendo datos del paciente",
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    Toast.makeText(this@Login, "Error obteniendo paciente", Toast.LENGTH_SHORT).show()
                 }
 
             } catch (e: Exception) {
-                Log.e("LOGIN", "Error obteniendo paciente", e)
                 Toast.makeText(this@Login, "Error: ${e.message}", Toast.LENGTH_SHORT).show()
             }
         }

--- a/app/src/main/java/com/andres_lasso/previmed/controller/asesor/PagosAdd.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/controller/asesor/PagosAdd.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.andres_lasso.previmed.databinding.ActivityPagosAddBinding
 import com.andres_lasso.previmed.interfaces.RetrofitClient
 import com.andres_lasso.previmed.model.*
+import com.andres_lasso.previmed.utils.PreferenceHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -22,7 +23,11 @@ class PagosAdd : AppCompatActivity() {
     private var listaFormasPago = listOf<FormaPago>()
     private var membresiaIdSeleccionada: Int = -1
     private var formaPagoIdSeleccionada: Int = -1
-    private val cobradorId = "65e38e38-24a3-45db-a257-caf42c2adc4c" // ID fijo de cobrador
+
+    // 🔥 Tomamos el ID del asesor logueado desde PreferenceHelper
+    private val asesorId: String by lazy {
+        PreferenceHelper.getIdAsesor(this) ?: ""
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -79,6 +84,10 @@ class PagosAdd : AppCompatActivity() {
             binding.etNumeroRecibo.text.isNullOrBlank() -> {
                 Toast.makeText(this, "Ingresa el número de recibo", Toast.LENGTH_SHORT).show(); false
             }
+            asesorId.isEmpty() -> {
+                Toast.makeText(this, "Error: No se encontró el ID del asesor", Toast.LENGTH_LONG).show()
+                false
+            }
             else -> true
         }
     }
@@ -102,7 +111,6 @@ class PagosAdd : AppCompatActivity() {
                         override fun onItemSelected(
                             parent: AdapterView<*>?, view: android.view.View?, position: Int, id: Long
                         ) {
-                            // Seleccionamos la membresía del primer elemento de la lista de membresias del paciente
                             membresiaIdSeleccionada =
                                 listaTitulares[position].membresiaPaciente?.firstOrNull()?.membresiaId ?: -1
                         }
@@ -149,6 +157,7 @@ class PagosAdd : AppCompatActivity() {
     }
 
     private fun registrarPago() {
+
         val monto = binding.etMonto.text.toString().toDouble()
         val fechaInicio = binding.etFechaInicio.text.toString()
         val fechaFin = binding.etFechaFin.text.toString()
@@ -162,7 +171,10 @@ class PagosAdd : AppCompatActivity() {
             fecha_pago = fechaPago,
             membresia_id = membresiaIdSeleccionada,
             forma_pago_id = formaPagoIdSeleccionada,
-            cobrador_id = cobradorId,
+
+            // 🔥 Cambio importante → ahora enviamos el asesor real
+            cobrador_id = asesorId,
+
             numero_recibo = numeroRecibo,
             estado = "Pendiente",
             foto = null

--- a/app/src/main/java/com/andres_lasso/previmed/controller/asesor/RegistrarPagoActivity.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/controller/asesor/RegistrarPagoActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.andres_lasso.previmed.R
 import com.andres_lasso.previmed.interfaces.RetrofitClient
 import com.andres_lasso.previmed.model.PagoRequest
+import com.andres_lasso.previmed.utils.PreferenceHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -28,7 +29,6 @@ class RegistrarPagoActivity : AppCompatActivity() {
 
     private var membresiaId: Int = -1
     private var formaPagoId: Int = -1
-    private val cobradorId = "65e38e38-24a3-45db-a257-caf42c2adc4c" // ID fijo de cobrador
 
     private val TAG = "RegistrarPago"
 
@@ -121,6 +121,15 @@ class RegistrarPagoActivity : AppCompatActivity() {
     }
 
     private fun registrarPago() {
+
+        // ⭐ AQUÍ TOMAMOS EL ID REAL DEL ASESOR
+        val idAsesor = PreferenceHelper.getIdAsesor(this)
+
+        if (idAsesor.isNullOrBlank()) {
+            Toast.makeText(this, "Error: no se encontró el ID del asesor", Toast.LENGTH_LONG).show()
+            return
+        }
+
         val monto = etMonto.text.toString().toDouble()
         val fechaInicio = etFechaInicio.text.toString()
         val fechaFin = etFechaFin.text.toString()
@@ -133,9 +142,9 @@ class RegistrarPagoActivity : AppCompatActivity() {
             fecha_pago = fechaPago,
             membresia_id = membresiaId,
             forma_pago_id = formaPagoId,
-            cobrador_id = null,     // 🔥 YA NO SE ENVÍA ID DE COBRADOR
-            numero_recibo = null,   // 🔥 COMO PagosAdd: no generamos recibo aquí
-            estado = "Pendiente",   // 🔥 SIEMPRE pendiente como pediste
+            cobrador_id = idAsesor,      // ⭐ SE ENVÍA EL ID DEL ASESOR CORRECTO
+            numero_recibo = null,
+            estado = "Pendiente",
             foto = null
         )
 
@@ -177,7 +186,6 @@ class RegistrarPagoActivity : AppCompatActivity() {
             }
         }
     }
-
 
     private fun limpiarCampos() {
         etMonto.text.clear()

--- a/app/src/main/java/com/andres_lasso/previmed/utils/PreferenceHelper.kt
+++ b/app/src/main/java/com/andres_lasso/previmed/utils/PreferenceHelper.kt
@@ -19,6 +19,7 @@ object PreferenceHelper {
         return context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
     }
 
+    // TOKEN
     fun saveToken(context: Context, token: String) {
         prefs(context).edit().putString(TOKEN_KEY, token).apply()
     }
@@ -26,14 +27,17 @@ object PreferenceHelper {
     fun hasToken(context: Context): Boolean = !getToken(context).isNullOrBlank()
     fun clearToken(context: Context) { prefs(context).edit().remove(TOKEN_KEY).apply() }
 
+    // ROLE
     private fun normalizeRole(role: String?): String {
         if (role.isNullOrBlank()) return ""
         val normalized = Normalizer.normalize(role, Normalizer.Form.NFD)
         return normalized.replace("\\p{Mn}+".toRegex(), "").lowercase()
     }
+
     fun saveRole(context: Context, role: String) {
         prefs(context).edit().putString(ROLE_KEY, normalizeRole(role)).apply()
     }
+
     fun getRole(context: Context): String? = normalizeRole(prefs(context).getString(ROLE_KEY, null))
     fun clearRole(context: Context) { prefs(context).edit().remove(ROLE_KEY).apply() }
 
@@ -50,6 +54,7 @@ object PreferenceHelper {
         prefs(context).edit().remove(ID_MEDICO_KEY).apply()
     }
 
+    // USUARIO
     fun saveUsuarioId(context: Context, usuarioId: String) {
         prefs(context).edit().putString(USUARIO_ID_KEY, usuarioId).apply()
     }
@@ -61,7 +66,8 @@ object PreferenceHelper {
     fun clearUsuarioId(context: Context) {
         prefs(context).edit().remove(USUARIO_ID_KEY).apply()
     }
-    //PACIENTE
+
+    // PACIENTE
     fun saveIdPaciente(context: Context, idPaciente: String) {
         prefs(context).edit().putString(ID_PACIENTE_KEY, idPaciente).apply()
     }
@@ -72,11 +78,13 @@ object PreferenceHelper {
 
     fun clearIdPaciente(context: Context) { prefs(context).edit().remove(ID_PACIENTE_KEY).apply() }
 
-    fun saveTelefono(context: Context, telefono: String) = prefs(context).edit().putString(TELEFONO_KEY, telefono).apply()
+    fun saveTelefono(context: Context, telefono: String) =
+        prefs(context).edit().putString(TELEFONO_KEY, telefono).apply()
+
     fun getTelefono(context: Context): String? = prefs(context).getString(TELEFONO_KEY, null)
     fun clearTelefono(context: Context) = prefs(context).edit().remove(TELEFONO_KEY).apply()
 
-    // 🟡 VISITA ACTIVA
+    // VISITA ACTIVA
     fun setVisitaActiva(context: Context, activa: Boolean) {
         prefs(context).edit().putBoolean(VISITA_ACTIVA_KEY, activa).apply()
     }
@@ -88,6 +96,22 @@ object PreferenceHelper {
     fun clearVisitaActiva(context: Context) {
         prefs(context).edit().remove(VISITA_ACTIVA_KEY).apply()
     }
+
+    // 🟢 ASESOR (NUEVO)
+    private const val ID_ASESOR_KEY = "id_asesor"
+
+    fun saveIdAsesor(context: Context, idAsesor: String) {
+        prefs(context).edit().putString(ID_ASESOR_KEY, idAsesor).apply()
+    }
+
+    fun getIdAsesor(context: Context): String? {
+        return prefs(context).getString(ID_ASESOR_KEY, null)
+    }
+
+    fun clearIdAsesor(context: Context) {
+        prefs(context).edit().remove(ID_ASESOR_KEY).apply()
+    }
+
     // BORRAR TODO
     fun clearSession(context: Context) {
         prefs(context).edit().clear().apply()


### PR DESCRIPTION
Este PR incorpora la gestión del ID del asesor autenticado dentro del proceso de registro de pagos, asegurando que cada transacción quede correctamente asociada al usuario que la realiza.
 Cambios principales

Se implementa PreferenceHelper para persistir el asesor_id recibido durante el login.
Se reemplaza el ID hardcoded previamente utilizado en PagosAddActivity y RegistrarPagoActivity.
Se actualiza la creación del PagoRequest para incluir el asesor real como parte del payload.
Se mejora el control de sesión al momento de iniciar la actividad, garantizando que siempre se utilice el ID correcto.

El flujo de registro de pagos ahora mantiene coherencia con el usuario autenticado, mejora la trazabilidad y elimina el uso de valores estáticos no seguros.